### PR TITLE
Fix auth redirect loop on register

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clean-arch-frontend-template",
   "type": "module",
-  "version": "0.6.48",
+  "version": "0.6.49",
   "private": true,
   "scripts": {
     "start": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clean-arch-frontend-template",
   "type": "module",
-  "version": "0.6.49",
+  "version": "0.6.48",
   "private": true,
   "scripts": {
     "start": "vite",

--- a/src/kernel/api/client.ts
+++ b/src/kernel/api/client.ts
@@ -1,6 +1,7 @@
 import type { AxiosError, AxiosResponse } from 'axios';
 import { ROUTES } from '@kernel/router';
 import { tokenStorage } from '@kernel/storage';
+import { useAuthStore } from '@kernel/stores';
 import axios from 'axios';
 
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
@@ -47,8 +48,11 @@ apiClient.interceptors.response.use(
 
     // Handle unauthorized
     if (error.response?.status === 401) {
-      tokenStorage.remove();
-      globalThis.location.href = ROUTES.auth.register.full;
+      useAuthStore.getState().clearToken();
+
+      if (globalThis.location.pathname !== ROUTES.auth.register.full) {
+        globalThis.location.replace(ROUTES.auth.register.full);
+      }
     }
 
     return Promise.reject(error);


### PR DESCRIPTION
## Summary
- Clear the persisted auth store on 401, not only the standalone access-token storage.
- Use location.replace() and skip redirecting when the user is already on /auth/register to prevent reload loops.

## Why
The app could keep auth.isAuth=true in the Zustand persisted store after an unauthorized response. On /auth/register, initialization still ran private requests, got another 401, and redirected back to the same route repeatedly.

## Verification
- npx eslint src/kernel/api/client.ts passed.
- npm run build passed.
- git diff --check passed.

## Existing unrelated failures
- npm run check-types currently fails in node_modules/@radix-ui/themes/src type files.
- Full npm run lint currently fails on existing repo-wide lint issues outside this change.